### PR TITLE
0.10.3 Fixes for non standard network

### DIFF
--- a/conf/tredly-host.conf.dist
+++ b/conf/tredly-host.conf.dist
@@ -8,22 +8,22 @@ wif=bridge0
 lif=bridge1
 
 # The physical interface that holds an ip address
-wifPhysical=bce0
+wifPhysical=
 
 ## The network and netmask for the lif, used for assigning ip addresses
-lifNetwork=10.0.0.0/16
+lifNetwork=
 
 ## Nameservers
-dns=10.0.255.254
+dns=
 
 ## HTTP Proxy Identifier
-httpproxy=10.0.255.254
+httpproxy=
 
 ## TLD of your servers - used for DNS entries
 tld=example.com
 
 ## Default route for your private container network
-vnetdefaultroute=10.0.255.254
+vnetdefaultroute=
 
 ## Adds logging to the firewall rules
 ## Set this to 'yes' to enable (case sensitive). Anything else is 

--- a/lib/ip4_functions.sh
+++ b/lib/ip4_functions.sh
@@ -468,8 +468,10 @@ function ip4_set_host_network() {
     fi
 
     # make sure the new ip address doesnt fall within the container subnet
-    if ip4_is_network_member "${_ip4}" "${_CONF_COMMON[lifNetwork]}/${_CONF_COMMON[lifCIDR]}"; then
-        exit_with_error "IP ${_ip4} falls within your container subnet. If you wish to use this ip address, please change your container subnet"
+    if [[ -n "${_CONF_COMMON[lifNetwork]}" ]]; then
+        if ip4_is_network_member "${_ip4}" "${_CONF_COMMON[lifNetwork]}/${_CONF_COMMON[lifCIDR]}"; then
+            exit_with_error "IP ${_ip4} falls within your container subnet. If you wish to use this ip address, please change your container subnet"
+        fi
     fi
 
     local _ip4Subnet=$( cidr2netmask "${_ip4CIDR}" )

--- a/tredly
+++ b/tredly
@@ -18,8 +18,8 @@ declare -a _SUBCOMMANDS
 declare -A _FLAGS
 
 # versioning
-_VERSIONNUMBER="0.10.2"
-_VERSIONDATE="May 12 2016"
+_VERSIONNUMBER="0.10.3"
+_VERSIONDATE="May 13 2016"
 
 _SHOW_HELP=false
 _ARGS=($@)


### PR DESCRIPTION
Remove hard coded values from tredly-host.conf
Better checking on whether ip falls in subnet (if lifNetwork blank then dont check)

Closes tredly/tredly-build#38
